### PR TITLE
Another way to find the document to be annotated from sections file.

### DIFF
--- a/src/main/java/ws/biotea/ld2rdf/annotation/model/NCBOAnnotation.java
+++ b/src/main/java/ws/biotea/ld2rdf/annotation/model/NCBOAnnotation.java
@@ -7,11 +7,13 @@ import java.util.Set;
 
 public class NCBOAnnotation {	
 	private List<String> annotatedClassIds;
+	private ArrayList<String> sourceOntologies;
 	private Set<PositionLocator> annotationFromTo;
 	private String annotationText;
 	
 	public NCBOAnnotation() {
 		this.annotatedClassIds = new ArrayList<String>();
+		this.setSourceOntologies(new ArrayList<String>());
 		this.annotationFromTo = new HashSet<>();
 	}
 
@@ -39,6 +41,14 @@ public class NCBOAnnotation {
 	 */
 	public List<String> getAnnotatedClassIds() {
 		return annotatedClassIds;
+	}
+
+	public ArrayList<String> getSourceOntologies() {
+		return sourceOntologies;
+	}
+
+	public void setSourceOntologies(ArrayList<String> sourceOntologies) {
+		this.sourceOntologies = sourceOntologies;
 	}
 
 	/**
@@ -84,6 +94,24 @@ public class NCBOAnnotation {
 		} else if (!annotationText.equals(other.annotationText))
 			return false;
 		return true;
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("NCBOAnnotation [annotatedClassIds=");
+		builder.append(annotatedClassIds);
+		builder.append(", sourceOntology=");
+		builder.append(sourceOntologies);
+		builder.append(", annotationFromTo=");
+		builder.append(annotationFromTo);
+		builder.append(", annotationText=");
+		builder.append(annotationText);
+		builder.append("]");
+		return builder.toString();
 	}
 	
 }


### PR DESCRIPTION
There is no way to know what document is going to be annotated in sections files. Before, the element annotated with the type bibo:AcademicArticle was retrieved. If there were more than one, then the first one was selected. This prevent the annotation of other documents annotated with other type. Therefore, only documents annotated with bibo:AcademicArticle type were being annotated.

Now I propose the function getBiboDocumentsExceptingReferences, which tries to retrieve the uri of the document that is going to be annotated. All bibo documents are iterated, and I check their URIs follow the biotea pattern while creating rdf document resources. If more than one, I select the first and I log a warning. This allows to annotate more documents in addition to bibo:AcademicArticle.

This pull request should be done together with other pull requests in rdfization and utils:

- https://github.com/biotea/biotea-rdfization/pull/2
- https://github.com/biotea/biotea-utilities/pull/1

Please, check if this is a good approach for being able to annotate other kind of documents in addition of bibo:AcademicArticle. I am not sure if these changes will have an impact in other features.